### PR TITLE
Use Release.Namespace instead of Values.config.namespace

### DIFF
--- a/charts/vsphere-csi/templates/NOTES.txt
+++ b/charts/vsphere-csi/templates/NOTES.txt
@@ -5,9 +5,9 @@ you should observe that there is one instance of the vsphere-csi-controller
 running on the master node and that an instance of the vsphere-csi-node is
 running on each of the worker nodes.
 
-$ kubectl get deployment --namespace={{ .Values.config.namespace }}
+$ kubectl get deployment --namespace={{ .Release.Namespace }}
 
-$ kubectl get daemonsets vsphere-csi-node --namespace={{ .Values.config.namespace }}
+$ kubectl get daemonsets vsphere-csi-node --namespace={{ .Release.Namespace }}
 
 
 # Verify that the vSphere CSI driver has been registered with Kubernetes #

--- a/charts/vsphere-csi/templates/clusterrolebinding.yaml
+++ b/charts/vsphere-csi/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: vsphere-csi-controller
-    namespace: {{ .Values.config.namespace }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: vsphere-csi-controller-role

--- a/charts/vsphere-csi/templates/csi-daemonset.yaml
+++ b/charts/vsphere-csi/templates/csi-daemonset.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: vsphere-csi-node
-  namespace: {{ .Values.config.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/charts/vsphere-csi/templates/csi-deployment.yaml
+++ b/charts/vsphere-csi/templates/csi-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vsphere-csi-controller
-  namespace: {{ .Values.config.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vsphere-csi.labels" . | nindent 4 }}
 spec:

--- a/charts/vsphere-csi/templates/secret.yaml
+++ b/charts/vsphere-csi/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.config.name }}
-  namespace: {{ .Values.config.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vsphere-csi.labels" . | nindent 4 }}
 stringData:

--- a/charts/vsphere-csi/templates/serviceaccount.yaml
+++ b/charts/vsphere-csi/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vsphere-csi-controller
-  namespace: {{ .Values.config.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vsphere-csi.labels" . | nindent 4 }}
 {{- end -}}

--- a/charts/vsphere-csi/values.yaml
+++ b/charts/vsphere-csi/values.yaml
@@ -20,13 +20,11 @@ global:
     username: "administrator@vsphere.local"
     password: "pass"
     datacenter: "datacenter"
-    namespace: kube-system
 
 config:
   enabled: true
   create: true
   name: "vsphere-config-secret"
-  namespace: kube-system
   clusterId: "cluster"
   port: 443
   cafile: "ca"


### PR DESCRIPTION
Based on what I saw in the vsphere-cpi helm chart, Release.namespace makes a *lot* more sense than putting namespace into values.